### PR TITLE
Added PerlRequire of startup.pl script

### DIFF
--- a/eg/conf/httpd.conf
+++ b/eg/conf/httpd.conf
@@ -1,4 +1,5 @@
 PerlPassEnv ACTHOME
+PerlRequire ${ACTHOME}/conf/startup.pl
 PerlModule Act::Auth
 PerlModule Act::Dispatcher
 PerlModule Act::Util


### PR DESCRIPTION
Added a PerlRequire instruction.
This should be needed in order to setup a correct mod_perl env for Act
